### PR TITLE
Add kernel dependency (Jammy)

### DIFF
--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -33,7 +33,9 @@ Standards-Version: 4.1.4
 
 Package: libnvidia-nscq-#BRANCH#
 Architecture: #ARCH_LIST#
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends:
+ nvidia-kernel-common-#BRANCH#-server (= ${binary:Version}),
+ ${misc:Depends}, ${shlibs:Depends}
 Provides: libnvidia-nscq, nscq#SONAME#
 Replaces: libnvidia-nscq
 Conflicts: libnvidia-nscq


### PR DESCRIPTION
Add a dependency between this package and
nvidia-kernel-common-#BRANCH#-server to keep the user space and kernel versions in sync.